### PR TITLE
Handle See Other (303) redirects.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -66,8 +66,18 @@ func MakeHandlerPage(f RequestHandler) http.HandlerFunc {
 		b.Reset()
 
 		res := f(r, w.Header(), b)
-		t.Stop()
-		WriteBytes(w, r, res, b, true)
+		t.Stop
+
+		switch res.Code {
+		case http.StatusSeeOther:
+			http.Redirect(w, r, res.Redirect, http.StatusSeeOther)
+
+			// change the Code to 200 for adding to the metrics.
+			// 303 is a successful post followed by a GET redirect.
+			res.Code = http.StatusOK
+		default:
+			WriteBytes(w, r, res, b, true)
+		}
 
 		t.Track(name(f) + "." + r.Method)
 		res.Count()

--- a/weft.go
+++ b/weft.go
@@ -28,6 +28,7 @@ type Result struct {
 	Ok   bool   // set true to indicate success
 	Code int    // http status code for writing back to the client e.g., http.StatusOK for success.
 	Msg  string // any error message for logging or to send to the client.
+	Redirect string // a URL to redirect to.  Use with Code = 3xx.
 }
 
 type RequestHandler func(r *http.Request, h http.Header, b *bytes.Buffer) *Result
@@ -42,6 +43,10 @@ func ServiceUnavailableError(err error) *Result {
 
 func BadRequest(message string) *Result {
 	return &Result{Ok: false, Code: http.StatusBadRequest, Msg: message}
+}
+
+func SeeOther(url string) *Result {
+	return &Result{Ok: true, Code: http.StatusSeeOther, Redirect: url}
 }
 
 /*


### PR DESCRIPTION
Resolves #12.

The idea behind this change is to be able to use weft with felt-rapid (and so replace all the extra code in there).  So it should allow for the logic here https://github.com/GeoNet/geonet-web/blob/master/felt/request_handler.go#L115

which could then be moved to the return from `func feltAction` as something like:

```
...
return  weft.SeeOther("/feltResult")
}
```