### PR TITLE
Added the MakeStreamHandlerAPI function

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -295,6 +295,36 @@ func BenchmarkMakeHandlerAPIGet(b *testing.B) {
 	}
 }
 
+func BenchmarkMakeStreamHandlerAPIGet(b *testing.B) {
+	var w *httptest.ResponseRecorder
+
+	r, err := http.NewRequest("GET", "http://test.com", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	h := func(r *http.Request, h http.Header, w http.ResponseWriter) *Result {
+		boganImpsum := []byte("bogan impsum bogan impsum")
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+		w.Write(boganImpsum)
+
+		return &StatusOK
+	}
+
+	fm := MakeStreamHandlerAPI(h)
+
+	for n := 0; n < b.N; n++ {
+		w = httptest.NewRecorder()
+		fm.ServeHTTP(w, r)
+	}
+}
+
 func BenchmarkMakeHandlerAPIPut(b *testing.B) {
 	var w *httptest.ResponseRecorder
 
@@ -308,6 +338,26 @@ func BenchmarkMakeHandlerAPIPut(b *testing.B) {
 	}
 
 	fm := MakeHandlerAPI(h)
+
+	for n := 0; n < b.N; n++ {
+		w = httptest.NewRecorder()
+		fm.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkMakeStreamHandlerAPIPut(b *testing.B) {
+	var w *httptest.ResponseRecorder
+
+	r, err := http.NewRequest("PUT", "http://test.com", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	h := func(r *http.Request, h http.Header, w http.ResponseWriter) *Result {
+		return &StatusOK
+	}
+
+	fm := MakeStreamHandlerAPI(h)
 
 	for n := 0; n < b.N; n++ {
 		w = httptest.NewRecorder()

--- a/weft.go
+++ b/weft.go
@@ -33,6 +33,8 @@ type Result struct {
 
 type RequestHandler func(r *http.Request, h http.Header, b *bytes.Buffer) *Result
 
+type RequestStreamHandler func(r *http.Request, h http.Header, w http.ResponseWriter) *Result
+
 func InternalServerError(err error) *Result {
 	return &Result{Ok: false, Code: http.StatusInternalServerError, Msg: err.Error()}
 }
@@ -99,7 +101,7 @@ func CheckQuery(r *http.Request, required, optional []string) *Result {
 }
 
 // name finds the name of the function f
-func name(f RequestHandler) string {
+func name(f interface{}) string {
 	var n string
 	// Find the name of the function f to use as the timer id
 	fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())

--- a/weft.go
+++ b/weft.go
@@ -22,6 +22,7 @@ var (
 	MethodNotAllowed = Result{Ok: false, Code: http.StatusMethodNotAllowed, Msg: "method not allowed"}
 	NotFound         = Result{Ok: false, Code: http.StatusNotFound, Msg: "not found"}
 	NotAcceptable    = Result{Ok: false, Code: http.StatusNotAcceptable, Msg: "specify accept"}
+	Unauthorized     = Result{Ok: false, Code: http.StatusUnauthorized, Msg: "Access denied"}
 )
 
 type Result struct {


### PR DESCRIPTION
This new Weft handler lets us write to the http.ResponseWriter directly for large streaming downloads.  The existing handlers use a bytes.Buffer parameter which needs to buffer everything in RAM.

This change is required for the dataselect implementation of FDSN in my branch.